### PR TITLE
Concatenate all participants data as "motiondata"

### DIFF
--- a/make_data.m
+++ b/make_data.m
@@ -25,6 +25,8 @@ labels(1,60*18+1:60*19) = 'playing basketball';
 
 %% load files
 
+label = {};
+motiondata = {};
 for i = 1:8
     person_number = strcat('p', num2str(i));
     tmp = {};
@@ -45,10 +47,12 @@ for i = 1:8
             X{k} = (dlmread(files(n).name,',')).';
         end
         tmp = horzcat(tmp,X);
+        motiondata = horzcat(motiondata,X);
         cd ../..
     end
     eval(['motiondata' num2str(i) '= tmp;']);
     eval(['labels' num2str(i) '= labels;']);
+    label = horzcat(label,labels);
 end
 
 save('DSADS.mat', 'motiondata1', 'labels')


### PR DESCRIPTION
Thank you for sharing this great work!

`svm_*.m` scripts seem to require `motiondata` and `label` variables which contains all participants data.
This patch will fix the errors because of that missing variables.
But still, in my environment (matlab R2019B + libsvm-3.24) the accuracy shown in `fig2.png` cannot be reproduced. So, something might be wrong with this patch.